### PR TITLE
config files

### DIFF
--- a/.qdb
+++ b/.qdb
@@ -1,0 +1,20 @@
+# Example .qdb file.
+config = QdbConfig(**{
+    'host': 'localhost',
+    'port': 8001,
+    'auth_msg': '',
+    'default_file': None,
+    'default_namespace': None,
+    'eval_fn': None,
+    'exception_serializer': None,
+    'skip_fn': None,
+    'pause_signal': None,
+    'redirect_output': True,
+    'retry_attepts': 10,
+    'uuid': 'qdb',
+    'cmd_manager': None,
+    'green': False,
+    'repr_fn': None,
+    'log_file': None,
+    'execution_timeout': None,
+})

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -4,6 +4,8 @@ gevent-websocket==0.9.3
 greenlet==0.4.2
 gipc==0.4.0
 
+six==1.7.3
+
 contextlib2==0.4.0
 
 Logbook==0.7.0

--- a/qdb/config.py
+++ b/qdb/config.py
@@ -1,0 +1,167 @@
+#
+# Copyright 2014 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import namedtuple
+from itertools import chain, repeat
+import os
+
+from logbook import Logger
+from six.moves import zip, reduce
+
+
+def _coerce_dict(dict_like):
+    if isinstance(dict_like, QdbConfig):
+        return dict_like._asdict()
+    return dict_like
+
+
+log = Logger('qdb_config')
+
+
+DEFAULT_OPTIONS = {
+    'host': 'localhost',
+    'port': 8001,
+    'auth_msg': '',
+    'default_file': None,
+    'default_namespace': None,
+    'eval_fn': None,
+    'exception_serializer': None,
+    'skip_fn': None,
+    'pause_signal': None,
+    'redirect_output': True,
+    'retry_attepts': 10,
+    'uuid': 'qdb',
+    'cmd_manager': None,
+    'green': False,
+    'repr_fn': None,
+    'log_file': None,
+    'execution_timeout': None,
+}
+
+
+class QdbConfig(namedtuple('QdbConfig', DEFAULT_OPTIONS)):
+    """
+    Qdb configuration.
+    """
+    filename = '.qdb'
+    DEFAULT_OPTIONS = DEFAULT_OPTIONS
+
+    kwargs_first = 1
+    config_first = -1
+
+    def __new__(cls, **kwargs):
+        """
+        A structure to hold the arguments to pass to Qdb.
+
+        Args:
+          host (str): The `host` of the server.
+          port (int): The `port` to connect on.
+          auth_msg (str): A message that will be sent with the start event
+            to the server. This can be used to do server/tracer authentication.
+          default_file (str): a file to use if the file field is ommited from
+            payloads.
+          eval_fn (function): The function to eval code where the user may
+            provide evaluate anything. For example in a conditional breakpoint
+            or in the repl.
+          exception_serializer (function): The function to convert exceptions
+            into strings to send back to the user.
+          skip_fn (function): Simmilar to the skip List feature of Bdb, except
+            that it should be a function that takes a filename and returns True
+            iff the debugger should skip this file. These files will be
+            suppressed from stack traces.
+          pause_signal (int): Signal to raise in this program to trigger a
+            pause command. If this is none, this will default to SIGUSR2.
+          retry_attempts (int): The number of times to attempt to connect to
+            the server before raising a QdbFailedToConnect error.
+          uuid (str): The identifier on the server for this session. If none is
+            provided, it will generate a uuid4.
+          cmd_manager (subclass of CommandManager): A callable that takes a Qdb
+            instance and manages commands by implementing a next_command
+            method. If none, a new, default manager will be created that reads
+            commands from the server at (`host`, `port`).
+          green (bool): If True, this will use gevent safe timeouts, otherwise
+            this will use signal based timeouts.
+          repr_fn (function): A function to use to convert objects to strings
+            to send then back to the server. By default, this wraps repr by
+            catching exceptions and reporting them to the user.
+          log_file (str): The file to log to, if None, log to stderr.
+          execution_timeout (int): The amount of time user code has to execute
+            before being cut short. This is applied to the repl, watchlist and
+            conditional breakpoints. If None, no timeout is applied.
+        """
+        extra = [k for k in kwargs if k not in cls.DEFAULT_OPTIONS]
+        if extra:
+            raise TypeError('QdbConfig received extra args: %s' % extra)
+
+        options = dict(cls.DEFAULT_OPTIONS)
+        options.update(kwargs)
+        return super(QdbConfig, cls).__new__(cls, **options)
+
+    @classmethod
+    def read_from_file(cls, filepath):
+        namespace = {}
+        try:
+            with open(filepath, 'r') as f:
+                exec(f.read(), {cls.__name__: cls}, namespace)
+        except IOError:
+            # Ignore missing files
+            log.debug('Skipping loading config from: %s' % filepath)
+
+        return namespace.get('config')
+
+    @classmethod
+    def get_config(cls,
+                   config=None,
+                   files=None,
+                   use_local=True,
+                   use_profile=True):
+        """
+        Gets a config, checking the project local config, the
+        user-set profile, and any addition files.
+        """
+        if isinstance(config, cls):
+            return config
+
+        if isinstance(config, dict):
+            return cls(**config)
+
+        files = files or ()
+        return cls().merge(
+            cls.read_from_file(filename)
+            for use, filename in chain(
+                ((use_profile, cls.get_profile()),
+                 (use_local, cls.get_local())),
+                zip(repeat(True), files),
+            )
+            if use
+        )
+
+    @classmethod
+    def get_profile(cls):
+        return os.path.join(os.path.expanduser('~'), cls.filename)
+
+    @classmethod
+    def get_local(cls):
+        return os.path.join(os.getcwd(), cls.filename)
+
+    def merge(self, configs):
+        return self._replace(**reduce(
+            lambda a, b: (b and a.update(_coerce_dict(b))) or a,
+            configs,
+            self._asdict(),
+        ))
+
+
+# This lives as a class level attribute on QdbConfig.
+del DEFAULT_OPTIONS

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,116 @@
+#
+# Copyright 2014 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from tempfile import mkdtemp, NamedTemporaryFile
+from textwrap import dedent
+from unittest import TestCase
+
+from qdb.config import QdbConfig
+
+
+class QdbConfigTester(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.contents = dedent(
+            """\
+            # FOR TESTING PURPOSES
+            config = QdbConfig(**{
+                'host': 'user-set',
+                'port': 'user-set',
+                'auth_msg': 'user-set',
+                'default_file': 'user-set',
+                'default_namespace': 'user-set',
+                'eval_fn': 'user-set',
+                'exception_serializer': 'user-set',
+                'skip_fn': 'user-set',
+                'pause_signal': 'user-set',
+                'redirect_output': 'user-set',
+                'retry_attepts': 'user-set',
+                'uuid': 'user-set',
+                'cmd_manager': 'user-set',
+                'green': 'user-set',
+                'repr_fn': 'user-set',
+                'log_file': 'user-set',
+                'execution_timeout': 'user-set',
+            })
+            """
+        )
+        cls.old_home = os.environ['HOME']
+        cls.home = mkdtemp()
+        os.environ['HOME'] = cls.home
+        cls.profile_path = os.path.join(cls.home, '.qdb')
+        cls.profile = open(cls.profile_path, 'w+')
+        cls.profile.write(cls.contents)
+        cls.profile.flush()
+
+        cls.expected = QdbConfig(
+            **{k: 'user-set' for k in QdbConfig.DEFAULT_OPTIONS}
+        )
+
+    @classmethod
+    def teardown(cls):
+        cls.profile.close()
+        os.remove(cls.profile_path)
+        os.rmdir(cls.home)
+        os.environ['HOME'] = cls.old_home
+
+    def _test_file(self, files=None, use_local=False, use_profile=False):
+        """
+        Tests reading a local file.
+        """
+        config = QdbConfig.get_config(
+            files=files, use_local=use_local, use_profile=use_profile,
+        )
+
+        self.assertEqual(self.expected._asdict(), config._asdict())
+
+    def test_local(self):
+        """
+        Tests reading the local file.
+        """
+        cwd = os.getcwd()
+        os.chdir(self.home)
+        try:
+            self._test_file(use_local=True)
+        finally:
+            os.chdir(cwd)
+
+    def test_profile(self):
+        """
+        Tests reading the profile file.
+        """
+        self._test_file(use_profile=True)
+
+    def test_extra(self):
+        """
+        Tests reading an extra config file.
+        """
+        with NamedTemporaryFile(dir=self.home) as t:
+            t.write(self.contents)
+            t.flush()
+
+            self._test_file(files=(t.name,))
+
+    def test_extra_arg(self):
+        """
+        Tests that passing an extra argument gets caught.
+        """
+        extra_arg = 'extra'
+        while extra_arg in QdbConfig.DEFAULT_OPTIONS:
+            # Assert athat extra_arg is NOT a valid option.
+            extra_arg += '_'
+
+        with self.assertRaisesRegexp(TypeError, extra_arg):
+            QdbConfig.get_config({extra_arg: None})

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -53,6 +53,10 @@ class TracerTester(TestCase):
         # Stop tracing after each test.
         sys.settrace(None)
 
+    def test_config_and_kwargs_no_merge(self):
+        with self.assertRaises(TypeError):
+            Qdb(config=True, merge=False, keyword=True)
+
     def test_as_ctx_mgr(self):
         """
         Tests the debugger as a context manager.


### PR DESCRIPTION
There are too many arguments to pass to `Qdb` to make setting breakpoints fast and simple.

This adds a `.qdb` file parser and scheme. The `QdbConfig` is a namedtuple that holds all the arguments to be passed to Qdb.

It checks for config files in:
- cwd
- `$HOME`
- Any files explicitly given.

`QdbConfig`s can also be constructed from a dict to make setting custom configs programatically simple.
