### PR TITLE
Add missing requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,10 +60,13 @@ setup(
         'Topic :: Software Development :: Debuggers',
     ],
     install_requires=[
+        'contextlib2',
         'gevent',
         'gevent-websocket',
         'gipc',
         'Logbook',
+        'six',
+        'websocket-client',
     ],
     url="https://github.com/quantopian/qdb"
 )


### PR DESCRIPTION
Attempting to run the server resulted in errors about missing modules. These are said modules.
