### PR TITLE
output redirection

### DIFF
--- a/qdb/comm.py
+++ b/qdb/comm.py
@@ -204,18 +204,6 @@ class CommandManager(object):
             }
         )
 
-    def send_output(self):
-        """
-        Sends a print that denotes that this is coming from the process.
-        This function is a nop if the tracer is not set to redirect the
-        stdout and stderr to the client.
-        """
-        if self.tracer.redirect_output:
-            self.send_print('<stdout>', False, self.tracer.stdout.getvalue())
-            self.send_print('<stderr>', False, self.tracer.stderr.getvalue())
-            # We don't need to cache this anymore.
-            self.tracer.clear_output_buffers()
-
     def send_error(self, error_type, error_data):
         """
         Sends a formatted error message.
@@ -730,7 +718,6 @@ class RemoteCommandManager(CommandManager):
         Sends back initial information and defers to user control.
         """
         self.send_breakpoints()
-        self.send_output()
         self.send_watchlist()
         self.send_stack()
         self.next_command()

--- a/qdb/output.py
+++ b/qdb/output.py
@@ -1,0 +1,116 @@
+#
+# Copyright 2014 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from abc import ABCMeta, abstractmethod
+from six import with_metaclass
+
+
+class WriteOnlyFileLike(with_metaclass(ABCMeta)):
+    def read(self, size=None):
+        # completeness of file-like object
+        raise IOError('%s object is write only' % self.__class__.__name__)
+    readline = read
+    readlines = read
+
+    def seek(self, offset, whence=None):
+        # completeness of file-like object
+        raise IOError('%s object cannot seek' % self.__class__.__name__)
+
+    @property
+    def mode(self):
+        return 'w'
+
+    def isatty(self):
+        return False
+
+    @abstractmethod
+    def write(self, msg):
+        raise NotImplementedError('write')
+
+    def writelines(self, msgs):
+        for msg in msgs:
+            self.write(msg)
+
+
+class RemoteOutput(WriteOnlyFileLike):
+    """
+    An object that reprents an output stream to the server.
+    This object implements a write only file-like object protocol.
+    """
+    def __init__(self, cmd_manager, name='<stdout>'):
+        self._cmd_manager = cmd_manager
+        self._name = name
+        self._closed = False
+
+    @property
+    def name(self):
+        return self._name
+
+    def write(self, msg):
+        if self._closed:
+            raise ValueError('%s object was closed' % self.__class__.__name__)
+
+        self._cmd_manager.send_print(self._name, False, msg)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        self._closed = True
+
+    @property
+    def closed(self):
+        return self._closed
+
+    def tell(self):
+        # completeness of file-like object
+        raise IOError('%s object cannot tell' % self.__class__.__name__)
+
+
+class OutputTee(WriteOnlyFileLike):
+    def __init__(self, first, second):
+        self._first = first
+        self._second = second
+
+    def close(self):
+        self._first.close()
+        self._second.close()
+
+    def flush(self):
+        self._first.flush()
+        self._second.flush()
+
+    def write(self, msg):
+        """
+        In order to send output to both sys.stdout and the client, we must
+        use our custom OutputTee object.
+
+        Note to users:
+          You might have been put here by stepping into a print statement
+          which will call sys.stdout.write internally. You may feel free
+          to return from this function as it is qdb code.
+        """
+        self._first.write(msg)
+        self._second.write(msg)
+
+    def writelines(self, msgs):
+        self._first.writelines(msgs)
+        self._second.writelines(msgs)
+
+    def __getattr__(self, name):
+        """
+        Other than the methods we have explicitly overridden, all other methods
+        should get sent to the first stream.
+        """
+        return getattr(self._first, name)

--- a/tests/test_cmd_manager.py
+++ b/tests/test_cmd_manager.py
@@ -62,10 +62,6 @@ class RemoteCommandManagerTester(TestCase):
         cls.setup_server()
         cls.cmd_manager = RemoteCommandManager
 
-    def tearDown(self):
-        if Qdb._instance:
-            Qdb._instance.disable()
-
     @classmethod
     def setup_server(cls):
         """
@@ -90,6 +86,10 @@ class RemoteCommandManagerTester(TestCase):
         Stop the test server.
         """
         cls.server.stop()
+
+    def tearDown(self):
+        if Qdb._instance:
+            Qdb._instance.disable()
 
     def MockTracer(self):
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,10 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections import namedtuple
 import gevent
 from gevent.queue import Queue, Empty
 
-from qdb.comm import CommandManager
+from qdb.comm import CommandManager, NopCommandManager
 
 try:
     import cPickle as pickle
@@ -69,3 +70,15 @@ class QueueCommandManager(CommandManager):
 
     def start(self, auth_msg=''):
         pass
+
+
+OutputMessage = namedtuple('OutputMessage', ['input_', 'exc', 'output'])
+
+
+class OutputCatchingNopCommandManager(NopCommandManager):
+    def __init__(self, tracer):
+        super(OutputCatchingNopCommandManager, self).__init__(tracer)
+        self.msgs = []
+
+    def send_print(self, input_, exc, output):
+        self.msgs.append(OutputMessage(input_, exc, output))


### PR DESCRIPTION
implements the output tee discussed in: #20

Also sends back std(out|err) as soon as it is hit instead of waiting for a point of user control.
