### PR TITLE
Shutdown fixes

### DIFF
--- a/qdb/comm.py
+++ b/qdb/comm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Quantopian, Inc.
+# Copyright 2015 Quantopian, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/qdb/comm.py
+++ b/qdb/comm.py
@@ -413,7 +413,7 @@ class RemoteCommandManager(CommandManager):
 
     def get_events(self):
         """
-        Infinitly yield events from the Reader.
+        Infinitely yield events from the Reader.
         """
         while self.reader.is_alive():
             try:
@@ -778,7 +778,7 @@ def get_events_from_socket(sck, green=False):
 
 class ServerReader(object):
     """
-    Object that reads from the server asyncronously from the process
+    Object that reads from the server asynchronously from the process
     being debugged.
     """
     def __init__(self, debugger_pipe, session_pid, server_comm_fd,
@@ -799,8 +799,8 @@ class ServerReader(object):
 
     def process_messages(self):
         """
-        Infinitly reads events off the server, if it is a pause, then it pauses
-        the process, otherwise, it passes the message along.
+        Infinitely reads events off the server. If it is a pause, then it
+        pauses the process; otherwise, it passes the message along.
         """
         # Send a message to alert the tracer that we are ready to begin reading
         # messages.

--- a/qdb/config.py
+++ b/qdb/config.py
@@ -69,7 +69,7 @@ class QdbConfig(namedtuple('QdbConfig', DEFAULT_OPTIONS)):
           port (int): The `port` to connect on.
           auth_msg (str): A message that will be sent with the start event
             to the server. This can be used to do server/tracer authentication.
-          default_file (str): a file to use if the file field is ommited from
+          default_file (str): a file to use if the file field is omitted from
             payloads.
           eval_fn (function): The function to eval code where the user may
             provide evaluate anything. For example in a conditional breakpoint

--- a/qdb/config.py
+++ b/qdb/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Quantopian, Inc.
+# Copyright 2015 Quantopian, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/qdb/server/__main__.py
+++ b/qdb/server/__main__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Quantopian, Inc.
+# Copyright 2015 Quantopian, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/qdb/server/__main__.py
+++ b/qdb/server/__main__.py
@@ -85,7 +85,7 @@ if __name__ == '__main__':
         '--sweep-time',
         type=int,
         metavar='SWEEP-TIME-MINS',
-        help='The amount of minutes in between sweeps of innactivity checks.',
+        help='The number of minutes in between sweeps of inactivity checks.',
         default=60,
     )
     argparser.add_argument(

--- a/qdb/server/__main__.py
+++ b/qdb/server/__main__.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
         metavar='TRACER-PORT',
         help='The port the tracer traffic will be served on.',
         default=8001,
-        )
+    )
     argparser.add_argument(
         '--client-host',
         type=str,

--- a/qdb/tracer.py
+++ b/qdb/tracer.py
@@ -466,14 +466,15 @@ class Qdb(Bdb, object):
             if self.log_handler:
                 self.log_handler.pop_application()
             self.cmd_manager.stop()
+            if sys.gettrace() is self.trace_dispatch:
+                sys.settrace(None)
 
     def __enter__(self):
         self.set_trace(sys._getframe().f_back, stop=False)
         return self
 
     def __exit__(self, type, value, traceback):
-        if isinstance(value, QdbQuit) or value is None:
-            self.disable('soft')
+        self.disable('soft')
 
     def set_trace(self, stackframe=None, stop=True):
         """

--- a/qdb/tracer.py
+++ b/qdb/tracer.py
@@ -65,7 +65,8 @@ class Qdb(Bdb, object):
         QdbConfig.config_first says kwargs will trample config.
         Otherwise, kwargs and config cannot both be passed.
         """
-        super(Qdb, self).__init__()
+        self.super_ = super(Qdb, self)
+        self.super_.__init__()
         self.reset()
         if config and kwargs:
             if merge == QdbConfig.kwargs_first:
@@ -237,10 +238,10 @@ class Qdb(Bdb, object):
         This means that the same json data that was used to set a break point
         may be fed into this function with the extra values ignored.
         """
-        super(Qdb, self).clear_break(filename, lineno)
+        self.super_.clear_break(filename, lineno)
 
     def canonic(self, filename):
-        canonic_filename = super(Qdb, self).canonic(filename)
+        canonic_filename = self.super_.canonic(filename)
         if canonic_filename.endswith('pyc'):
             return canonic_filename[:-1]
         return canonic_filename
@@ -394,7 +395,7 @@ class Qdb(Bdb, object):
             return self.trace_dispatch
 
         try:
-            return super(Qdb, self).trace_dispatch(stackframe, event, arg)
+            return self.super_.trace_dispatch(stackframe, event, arg)
         except BdbQuit:
             raise QdbQuit()  # Rewrap as a QdbError object.
 

--- a/qdb/tracer.py
+++ b/qdb/tracer.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Quantopian, Inc.
+# Copyright 2015 Quantopian, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/qdb/utils.py
+++ b/qdb/utils.py
@@ -297,7 +297,7 @@ def progn(src, eval_fn=None, stackframe=None):
         eval_fn(code, stackframe, 'exec', original=src)
     finally:
         # Always remove the register function from the namespace.
-        # This is to not fill the namespace after mutliple calls to progn.
+        # This is to not fill the namespace after multiple calls to progn.
         del stackframe.f_globals[register_name]
     try:
         # Attempt to retrieve the last expression.

--- a/qdb/utils.py
+++ b/qdb/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Quantopian, Inc.
+# Copyright 2015 Quantopian, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/qdb/utils.py
+++ b/qdb/utils.py
@@ -122,7 +122,7 @@ class QdbTimeout(QdbError):
         return 'Timed out after %s seconds' % self.seconds
 
     def __repr__(self):
-        return 'QdbTimeout(seconds=%s, exception=%s, timer_signal=%)' \
+        return 'QdbTimeout(seconds=%s, exception=%s, timer_signal=%s)' \
             % (self.seconds, self.exception, signal_module.SIGALRM)
 
 


### PR DESCRIPTION
1. During interpreter shutdown, the trace function blows up with a ```TypeError``` by calling super on ```Qdb```, which has been set to ```None``` by that time.  Here we cache the value on the ```Qdb``` instance, so it's available during shutdown.
1. Unset the sys trace function on Qdb context manager exit.  I would expect that exiting the Qdb instance wouldn't leave it tracing - is that correct?