### PR TITLE
Py3 tracer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
 
 install:
   - make requirements

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,4 @@ test:
 requirements:
 	pip install -r etc/requirements_dev.txt
 	pip install -r etc/requirements.txt
+	python -c 'import sys;exit(int(sys.version_info.major != 2))' && pip install -r etc/requirements_gevent.txt

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,6 @@ test:
 requirements:
 	pip install -r etc/requirements_dev.txt
 	pip install -r etc/requirements.txt
-	python -c 'import sys;exit(int(sys.version_info.major != 2))' && pip install -r etc/requirements_gevent.txt
+ifeq ($(shell python -c 'import sys;print(sys.version_info.major)'),2)
+	pip install -r etc/requirements_gevent.txt
+endif

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # qdb #
+[![build status](https://travis-ci.org/quantopian/qdb.png?branch=master)](https://travis-ci.org/quantopian/qdb)
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/quantopian/qdb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -1,11 +1,3 @@
-# Gevent related
-gevent==1.0.1
-gevent-websocket==0.9.3
-greenlet==0.4.2
-gipc==0.4.0
-
-six==1.7.3
-
 contextlib2==0.4.0
 
 Logbook==0.7.0

--- a/etc/requirements_gevent.txt
+++ b/etc/requirements_gevent.txt
@@ -1,0 +1,5 @@
+# Gevent related
+gevent==1.0.1
+gevent-websocket==0.9.3
+greenlet==0.4.2
+gipc==0.4.0

--- a/qdb/comm.py
+++ b/qdb/comm.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import print_function
-
 from abc import ABCMeta, abstractmethod
 import atexit
 from bdb import Breakpoint

--- a/qdb/comm.py
+++ b/qdb/comm.py
@@ -112,8 +112,7 @@ class CommandManager(object):
 
     def __init__(self, tracer):
         self.tracer = tracer
-        self.green = self.tracer.green
-        if self.green:
+        if gevent is not None:
             import gipc  # Only use gipc if we are running in gevent.
             self._pipe = gipc.pipe
             self._start_process = gipc.start_process
@@ -776,7 +775,7 @@ class RemoteCommandManager(CommandManager):
         self.tracer.disable(payload)
 
 
-def get_events_from_socket(sck, green=False):
+def get_events_from_socket(sck):
     """
     Yields valid events from the server socket.
     """
@@ -788,7 +787,7 @@ def get_events_from_socket(sck, green=False):
             rlen = unpack('>i', rlen)[0]
             bytes_received = 0
             resp = b''
-            with Timeout(1, False, green=green):
+            with Timeout(1, False):
                 while bytes_received < rlen:
                     resp += sck.recv(rlen - bytes_received)
                     bytes_received = len(resp)

--- a/qdb/comm.py
+++ b/qdb/comm.py
@@ -69,7 +69,7 @@ def fmt_msg(event, payload=None, serial=None):
     """
     Packs a message to be sent to the server.
     Serial is a function to call on the frame to serialize it, e.g:
-    json.dumps or json.dumps
+    json.dumps.
     """
     frame = {
         'e': event,

--- a/qdb/comm.py
+++ b/qdb/comm.py
@@ -799,7 +799,6 @@ def get_events_from_socket(sck, green=False):
 
             if PY3:
                 resp = resp.decode('utf-8')
-            print(resp)
 
             cmd = json.loads(resp)
             if cmd['e'] == 'disabled':

--- a/qdb/comm.py
+++ b/qdb/comm.py
@@ -12,11 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
+
 from abc import ABCMeta, abstractmethod
 import atexit
 from bdb import Breakpoint
 import errno
 from itertools import takewhile
+import json
 import os
 from pprint import pformat
 import signal
@@ -25,9 +28,9 @@ from struct import pack, unpack
 import sys
 
 from contextlib2 import contextmanager
-import gipc
 from logbook import Logger
 
+from qdb.compat import StringIO, range, PY3, items, Connection
 from qdb.errors import (
     QdbFailedToConnect,
     QdbBreakpointReadError,
@@ -37,16 +40,6 @@ from qdb.errors import (
     QdbPrognEndsInStatement,
 )
 from qdb.utils import Timeout, progn
-
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
 
 log = Logger('Qdb')
 
@@ -76,7 +69,7 @@ def fmt_msg(event, payload=None, serial=None):
     """
     Packs a message to be sent to the server.
     Serial is a function to call on the frame to serialize it, e.g:
-    json.dumps or pickle.dumps
+    json.dumps or json.dumps
     """
     frame = {
         'e': event,
@@ -120,6 +113,25 @@ class CommandManager(object):
     def __init__(self, tracer):
         self.tracer = tracer
         self.green = self.tracer.green
+        if self.green:
+            import gipc  # Only use gipc if we are running in gevent.
+            self._pipe = gipc.pipe
+            self._start_process = gipc.start_process
+        else:
+            import multiprocessing
+
+            def _pipe(*args, **kwargs):
+                a, b = multiprocessing.Pipe(*args, **kwargs)
+                return Connection(a), Connection(b)
+
+            self._pipe = _pipe
+
+            def _start_process(*args, **kwargs):
+                proc = multiprocessing.Process(*args, **kwargs)
+                proc.start()
+                return proc
+
+            self._start_process = _start_process
 
     def _fmt_stackframe(self, stackframe, line):
         """
@@ -163,7 +175,7 @@ class CommandManager(object):
         self.send_event(
             'watchlist',
             [{'expr': k, 'exc': exc, 'value': val}
-             for k, (exc, val) in self.tracer.watchlist.iteritems()],
+             for k, (exc, val) in items(self.tracer.watchlist)],
         )
 
     def send_print(self, input, exc, output):
@@ -176,7 +188,7 @@ class CommandManager(object):
                 'exc': exc,
                 'output': output
             },
-            serial=pickle.dumps)
+            serial=json.dumps)
         )
 
     def send_stack(self):
@@ -209,13 +221,13 @@ class CommandManager(object):
         """
         Sends a formatted error message.
         """
-        self.send(fmt_err_msg(error_type, error_data, serial=pickle.dumps))
+        self.send(fmt_err_msg(error_type, error_data, serial=json.dumps))
 
     def send_event(self, event, payload=None):
         """
         Sends a formatted event.
         """
-        self.send(fmt_msg(event, payload, serial=pickle.dumps))
+        self.send(fmt_msg(event, payload, serial=json.dumps))
 
     def next_command(self, msg=None):
         """
@@ -230,7 +242,7 @@ class CommandManager(object):
     @abstractmethod
     def send(self, msg):
         """
-        Sends a raw (already pickled) message.
+        Sends a raw (already jsond) message.
         """
         raise NotImplementedError
 
@@ -305,7 +317,7 @@ class RemoteCommandManager(CommandManager):
         """
         Connects to the socket or raise a QdbFailedToConnect error.
         """
-        for n in xrange(self.tracer.retry_attepts):
+        for n in range(self.tracer.retry_attepts):
             # Try to connect to the server.
             try:
                 self.socket = socket.create_connection(self.tracer.address)
@@ -334,9 +346,9 @@ class RemoteCommandManager(CommandManager):
         """
         Begins processing commands from the server.
         """
-        self.pipe, child_end = gipc.pipe()
+        self.pipe, child_end = self._pipe()
         self._socket_connect()
-        self.reader = gipc.start_process(
+        self.reader = self._start_process(
             target=ServerReader,
             args=(child_end, os.getpid(),
                   self.socket.fileno(),
@@ -346,7 +358,14 @@ class RemoteCommandManager(CommandManager):
                                            self.tracer.retry_attepts),
                      green=self.green):
             # Receive a message to know that the reader is ready to begin.
-            self.pipe.get()
+            while True:
+                try:
+                    self.pipe.get()
+                    break
+                except IOError as e:
+                    # EAGAIN says to try the syscall again.
+                    if e.errno != errno.EAGAIN:
+                        raise
 
         self.send(
             fmt_msg(
@@ -355,7 +374,7 @@ class RemoteCommandManager(CommandManager):
                     'auth': auth_msg,
                     'local': (0, 0),
                 },
-                serial=pickle.dumps,
+                serial=json.dumps,
             )
         )
         atexit.register(self.stop)
@@ -393,7 +412,7 @@ class RemoteCommandManager(CommandManager):
         Sends a message to the server.
         """
         self.socket.sendall(pack('>i', len(msg)))
-        self.socket.sendall(msg)
+        self.socket.sendall(msg.encode('utf-8'))
 
     def payload_check(self, payload, command):
         """
@@ -564,7 +583,7 @@ class RemoteCommandManager(CommandManager):
         try:
             breakpoint = self.fmt_breakpoint_dict(payload)
         except QdbBreakpointReadError as b:
-            err_msg = fmt_err_msg('set_break', str(b), serial=pickle.dumps)
+            err_msg = fmt_err_msg('set_break', str(b), serial=json.dumps)
             return self.next_command(err_msg)
 
         try:
@@ -573,7 +592,7 @@ class RemoteCommandManager(CommandManager):
             err_msg = fmt_err_msg(
                 'set_breakpoint',
                 str(u),
-                serial=pickle.dumps
+                serial=json.dumps
             )
             return self.next_command(err_msg)
 
@@ -588,7 +607,7 @@ class RemoteCommandManager(CommandManager):
         try:
             breakpoint = self.fmt_breakpoint_dict(payload)
         except QdbBreakpointReadError as b:
-            err_msg = fmt_err_msg('clear_break', str(b), serial=pickle.dumps)
+            err_msg = fmt_err_msg('clear_break', str(b), serial=json.dumps)
             return self.next_command(err_msg)
 
         self.tracer.clear_break(**breakpoint)
@@ -609,7 +628,7 @@ class RemoteCommandManager(CommandManager):
                 msg = fmt_msg(
                     'list',
                     self.tracer.get_file(payload['file']),
-                    serial=pickle.dumps
+                    serial=json.dumps
                 )
             else:
                 # Send back the slice of the file that they requested.
@@ -620,13 +639,13 @@ class RemoteCommandManager(CommandManager):
                             int(payload.get('start')):int(payload.get('end'))
                         ]
                     ),
-                    serial=pickle.dumps
+                    serial=json.dumps
                 )
         except KeyError:  # The file failed to be cached.
             msg = fmt_err_msg(
                 'list',
                 'File %s does not exist' % payload['file'],
-                serial=pickle.dumps
+                serial=json.dumps
             )
         except TypeError:
             # This occurs when we fail to convert the 'start' or 'stop' fields
@@ -634,7 +653,7 @@ class RemoteCommandManager(CommandManager):
             msg = fmt_err_msg(
                 'list',
                 'List slice arguments must be convertable to type int',
-                serial=pickle.dumps
+                serial=json.dumps
             )
 
         self.next_command(msg)
@@ -752,7 +771,7 @@ class RemoteCommandManager(CommandManager):
             err_msg = fmt_err_msg(
                 'disable',
                 "payload must be either 'soft' or 'hard'",
-                serial=pickle.dumps
+                serial=json.dumps
             )
             return self.next_command(err_msg)
         self.tracer.disable(payload)
@@ -769,7 +788,7 @@ def get_events_from_socket(sck, green=False):
                 return
             rlen = unpack('>i', rlen)[0]
             bytes_received = 0
-            resp = ''
+            resp = b''
             with Timeout(1, False, green=green):
                 while bytes_received < rlen:
                     resp += sck.recv(rlen - bytes_received)
@@ -778,11 +797,15 @@ def get_events_from_socket(sck, green=False):
             if bytes_received != rlen:
                 return  # We are not getting bytes anymore.
 
-            cmd = pickle.loads(resp)
+            if PY3:
+                resp = resp.decode('utf-8')
+            print(resp)
+
+            cmd = json.loads(resp)
             if cmd['e'] == 'disabled':
                 # We are done tracing.
                 return
-        except (socket.error, pickle.UnpicklingError) as e:
+        except (socket.error, ValueError) as e:
             # We can no longer talk the the server.
             log.warn('Exception raised reading from socket')
             yield fmt_err_msg('socket', str(e))
@@ -859,7 +882,7 @@ class ServerLocalCommandManager(RemoteCommandManager):
                     'auth': auth_msg,
                     'local': (os.getpid(), self.tracer.pause_signal),
                 },
-                serial=pickle.dumps,
+                serial=json.dumps,
             )
         )
 

--- a/qdb/comm.py
+++ b/qdb/comm.py
@@ -30,7 +30,7 @@ import sys
 from contextlib2 import contextmanager
 from logbook import Logger
 
-from qdb.compat import StringIO, range, PY3, items, Connection
+from qdb.compat import StringIO, range, PY3, items, Connection, gevent
 from qdb.errors import (
     QdbFailedToConnect,
     QdbBreakpointReadError,
@@ -355,8 +355,7 @@ class RemoteCommandManager(CommandManager):
                   self.tracer.pause_signal),
         )
         with Timeout(5, QdbFailedToConnect(self.tracer.address,
-                                           self.tracer.retry_attepts),
-                     green=self.green):
+                                           self.tracer.retry_attepts)):
             # Receive a message to know that the reader is ready to begin.
             while True:
                 try:

--- a/qdb/compat.py
+++ b/qdb/compat.py
@@ -11,6 +11,9 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
+import sys
+
+
 try:
     reduce = reduce
     PY2 = True
@@ -22,10 +25,7 @@ except NameError:
 PY3 = not PY2
 
 
-try:
-    import gevent
-except ImportError:
-    gevent = None
+gevent = sys.modules.get('gevent')
 
 
 if PY2:

--- a/qdb/compat.py
+++ b/qdb/compat.py
@@ -1,0 +1,77 @@
+try:
+    reduce = reduce
+    PY2 = True
+except NameError:
+    from functools import reduce
+    PY2 = False
+
+
+PY3 = not PY2
+
+
+try:
+    import gevent
+except ImportError:
+    gevent = None
+
+
+if PY2:
+    try:
+        from cStringIO import StringIO
+    except ImportError:
+        from StringIO import StringIO
+
+    import itertools
+
+    filter = itertools.ifilter
+    items = dict.iteritems
+    map = itertools.imap
+    range = xrange  # NOQA
+    zip = itertools.izip
+
+else:
+    from io import StringIO
+
+    filter = filter
+    items = dict.items
+    map = map
+    range = range
+    zip = zip
+
+
+class Connection(object):
+    """
+    A wrapper for a multiprocessing connection to emulate gipc pipes.
+    """
+    def __init__(self, conn):
+        self.__conn = conn
+
+    def put(self, *args, **kwargs):
+        return self.__conn.send(*args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        return self.__conn.recv(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self.__conn, name)
+
+
+def with_metaclass(metaclass, *bases):
+    """
+    Adds a new base in the mro for python 2 and 3 compatible
+    metaclass syntax.
+    """
+    return metaclass('SurrogateBase', bases, {})
+
+
+__all__ = [
+    'Connection',
+    'PY2',
+    'PY3',
+    'StringIO',
+    'gevent',
+    'items',
+    'range',
+    'reduce',
+    'zip',
+]

--- a/qdb/compat.py
+++ b/qdb/compat.py
@@ -1,3 +1,16 @@
+#
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 try:
     reduce = reduce
     PY2 = True
@@ -21,19 +34,24 @@ if PY2:
     except ImportError:
         from StringIO import StringIO
 
+    from contextlib2 import ExitStack
+
     import itertools
 
     filter = itertools.ifilter
     items = dict.iteritems
+    keys = dict.iterkeys
     map = itertools.imap
     range = xrange  # NOQA
     zip = itertools.izip
 
 else:
+    from contextlib import ExitStack
     from io import StringIO
 
     filter = filter
     items = dict.items
+    keys = dict.keys
     map = map
     range = range
     zip = zip
@@ -66,6 +84,7 @@ def with_metaclass(metaclass, *bases):
 
 __all__ = [
     'Connection',
+    'ExitStack',
     'PY2',
     'PY3',
     'StringIO',

--- a/qdb/config.py
+++ b/qdb/config.py
@@ -17,7 +17,8 @@ from itertools import chain, repeat
 import os
 
 from logbook import Logger
-from six.moves import zip, reduce
+
+from qdb.compat import reduce, zip
 
 
 def _coerce_dict(dict_like):

--- a/qdb/output.py
+++ b/qdb/output.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABCMeta, abstractmethod
-from six import with_metaclass
+
+from qdb.compat import with_metaclass
 
 
 class WriteOnlyFileLike(with_metaclass(ABCMeta)):

--- a/qdb/server/session_store.py
+++ b/qdb/server/session_store.py
@@ -29,11 +29,6 @@ from gevent.event import Event
 from geventwebsocket import WebSocketError
 from logbook import Logger
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-
 from qdb.comm import fmt_msg, fmt_err_msg
 
 
@@ -243,7 +238,7 @@ class SessionStore(object):
             # Signal to the tracer that no client attached.
             self._send_to_socket(socket, fmt_err_msg(
                 'client', 'No client',
-                serial=pickle.dumps
+                serial=json.dumps
             ))
             self.slaughter(uuid, self.timeout_disable_mode)
             log.warn('No client came to debug %s' % uuid)
@@ -334,8 +329,8 @@ class SessionStore(object):
                          % (self._sessions[uuid].pause_signal, uuid))
                 self._update_timestamp(uuid)
                 return  # We 'sent' this event.
-            msg = fmt_msg(event['e'], event.get('p'), serial=pickle.dumps)
-        except (pickle.PicklingError, KeyError) as e:
+            msg = fmt_msg(event['e'], event.get('p'), serial=json.dumps)
+        except (ValueError, KeyError) as e:
             log.warn('send_to_tracer(uuid=%s, event=%s) failed: %s'
                      % (uuid, event, e))
             raise  # The event is just wrong, reraise this to the user.

--- a/qdb/server/tracer.py
+++ b/qdb/server/tracer.py
@@ -12,17 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import socket
 from struct import pack
 
 from gevent import Timeout
 from gevent.server import StreamServer
 from logbook import Logger
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
 
 from qdb.comm import get_events_from_socket
 from qdb.server.serverbase import QdbServerBase
@@ -135,7 +131,7 @@ class QdbTracerServer(QdbServerBase, StreamServer):
                 }
 
                 auth_failed_dict['p']['data'] = message
-                err_msg = pickle.dumps(auth_failed_dict)
+                err_msg = json.dumps(auth_failed_dict)
                 conn.sendall(pack('>i', len(err_msg)))
                 conn.sendall(err_msg)
                 log.warn('Invalid start message from (%s, %d)' % addr)

--- a/qdb/server/tracer.py
+++ b/qdb/server/tracer.py
@@ -66,7 +66,7 @@ class QdbTracerServer(QdbServerBase, StreamServer):
         Reads a single message.
         """
         try:
-            return next(get_events_from_socket(conn, green=True))
+            return next(get_events_from_socket(conn))
         except StopIteration:
             return {}
 
@@ -148,7 +148,7 @@ class QdbTracerServer(QdbServerBase, StreamServer):
             ):
                 return  # No browser so the attach failed.
 
-            for event in get_events_from_socket(conn, green=True):
+            for event in get_events_from_socket(conn):
                 # Send the serialized event back to the browser.
                 self.session_store.send_to_clients(uuid, event=event)
 

--- a/qdb/tracer.py
+++ b/qdb/tracer.py
@@ -83,7 +83,6 @@ class Qdb(Bdb, object):
         self.exception_serializer = config.exception_serializer or \
             default_exception_serializer
         self.eval_fn = config.eval_fn or default_eval_fn
-        self.green = config.green
         self._file_cache = {}
         self.redirect_output = config.redirect_output
         self.retry_attepts = config.retry_attepts
@@ -135,13 +134,13 @@ class Qdb(Bdb, object):
         Return a new execution timeout context manager.
         If not execution timeout is in place, returns ExitStack()
         """
-        # We use green=False because this could be cpu bound. This will
+        # We use no_gevent=True because this could be cpu bound. This will
         # still throw to the proper greenlet if this is gevented.
         return (
             Timeout(
                 self.execution_timeout,
                 QdbExecutionTimeout(src, self.execution_timeout),
-                green=False
+                no_gevent=True,
             ) if self.execution_timeout else ExitStack()
         )
 

--- a/qdb/tracer.py
+++ b/qdb/tracer.py
@@ -13,17 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from bdb import Bdb, Breakpoint, checkfuncname, BdbQuit
+from contextlib import contextmanager
 import json
 import signal
 import sys
 import traceback
 from uuid import uuid4
 
-from contextlib2 import ExitStack, contextmanager
 from logbook import Logger, FileHandler
 
 from qdb.comm import RemoteCommandManager, fmt_msg
-from qdb.compat import map, items
+from qdb.compat import map, items, ExitStack
 from qdb.config import QdbConfig
 from qdb.errors import QdbUnreachableBreakpoint, QdbQuit, QdbExecutionTimeout
 from qdb.output import RemoteOutput, OutputTee

--- a/qdb/utils.py
+++ b/qdb/utils.py
@@ -66,6 +66,9 @@ class QdbTimeout(QdbError):
         exception is the exception to raise in the case of a timeout.
         When exception is ommited or None, the QdbTimeout itself is raised.
         """
+        if isinstance(seconds, float):
+            seconds = int(seconds + 1)
+
         if not isinstance(seconds, int):
             raise ValueError('integer argument expected, got %s'
                              % type(seconds).__name__)

--- a/qdb/utils.py
+++ b/qdb/utils.py
@@ -60,7 +60,7 @@ class QdbTimeout(QdbError):
             if t is u:
                 cleanup()
     """
-    def __init__(self, seconds, exception=None, green=False):
+    def __init__(self, seconds, exception=None, no_gevent=True):
         """
         seconds is the number of seconds to run this Timeout for.
         exception is the exception to raise in the case of a timeout.
@@ -143,15 +143,15 @@ if gevent is not None:
         _TimeoutMagic is really just a tuple that can be called to
         get a new Timeout that is either gevented or not.
         """
-        def __call__(self, seconds, exception=None, green=False):
+        def __call__(self, seconds, exception=None, no_gevent=False):
             """
             A timeout smart constructor that returns a
             gevent.Timeout or a QdbTimeout.
             """
-            if green:
-                timeout = gevent.Timeout
-            else:
+            if gevent is None or no_gevent:
                 timeout = QdbTimeout
+            else:
+                timeout = gevent.Timeout
 
             return timeout(seconds, exception)
 
@@ -168,7 +168,7 @@ if gevent is not None:
     # Also, because the __call__ has been overridden, you can get
     # the proper timeout by calling:
     #
-    # Timeout(seconds, green=is_green)
+    # Timeout(seconds)
     #
     # Timeout is capitalized because in almost all use cases you
     # can think of this as a class, even though there is a little

--- a/qdb/utils.py
+++ b/qdb/utils.py
@@ -18,10 +18,10 @@ import signal as signal_module
 import sys
 import tokenize
 
-import gevent
 from uuid import uuid4
 
 from qdb.errors import QdbError, QdbPrognEndsInStatement
+from qdb.compat import gevent, PY2
 
 
 def default_eval_fn(src, stackframe, mode='eval', original=None):
@@ -60,7 +60,7 @@ class QdbTimeout(QdbError):
             if t is u:
                 cleanup()
     """
-    def __init__(self, seconds, exception=None):
+    def __init__(self, seconds, exception=None, green=False):
         """
         seconds is the number of seconds to run this Timeout for.
         exception is the exception to raise in the case of a timeout.
@@ -74,13 +74,21 @@ class QdbTimeout(QdbError):
         self._existing_handler = None
         self.seconds = seconds
         self._running = False
-        self._greenlet = gevent.getcurrent()
+
+        if gevent is not None:
+            self._greenlet = gevent.getcurrent()
+        else:
+            self._greenlet = None
 
     def _signal_handler(self, signum, stackframe):
         if self._running:
             # Restore the orignal handler in case it times out.
             signal_module.signal(signal_module.SIGALRM, self._existing_handler)
-            self._greenlet.throw(self._exception or self)
+            exc = self._exception or self
+            if gevent is None:
+                raise exc
+            else:
+                self._greenlet.throw(exc)
 
     def start(self):
         """
@@ -123,49 +131,52 @@ class QdbTimeout(QdbError):
 
     def __repr__(self):
         return 'QdbTimeout(seconds=%s, exception=%s, timer_signal=%s)' \
-            % (self.seconds, self.exception, signal_module.SIGALRM)
+            % (self.seconds, self._exception, signal_module.SIGALRM)
 
 
-class _TimeoutMagic(tuple):
-    """
-    _TimeoutMagic is really just a tuple that can be called to get a new
-    Timeout that is either gevented or not.
-    """
-    def __call__(self, seconds, exception=None, green=False):
+if gevent is not None:
+    class _TimeoutMagic(tuple):
         """
-        A timeout smart constructor that returns a gevent.Timeout or a
-        QdbTimeout.
+        _TimeoutMagic is really just a tuple that can be called to
+        get a new Timeout that is either gevented or not.
         """
-        if green:
-            timeout = gevent.Timeout
-        else:
-            timeout = QdbTimeout
+        def __call__(self, seconds, exception=None, green=False):
+            """
+            A timeout smart constructor that returns a
+            gevent.Timeout or a QdbTimeout.
+            """
+            if green:
+                timeout = gevent.Timeout
+            else:
+                timeout = QdbTimeout
 
-        return timeout(seconds, exception)
+            return timeout(seconds, exception)
 
-
-# The way this works is that in an except block, if you pass a tuple of
-# exceptions, it will compare the exception to each of the exceptions in the
-# tuple. Therefore, if you write:
-#
-# except Timeout:
-#
-# You can think of it as expanding to:
-#
-# except (gevent.Timeout, QdbTimeout):
-#
-# Also, because the __call__ has been overridden, you can get the proper
-# timeout by calling:
-#
-# Timeout(seconds, green=is_green)
-#
-# Timeout is capitalized because in almost all use cases you can think of
-# this as a class, even though there is a little more going on.
-Timeout = _TimeoutMagic([gevent.Timeout, QdbTimeout])
+    # The way this works is that in an except block, if you pass a
+    # tuple of exceptions, it will compare the exception to each of
+    # the exceptions in the tuple. Therefore, if you write:
+    #
+    # except Timeout:
+    #
+    # You can think of it as expanding to:
+    #
+    # except (gevent.Timeout, QdbTimeout):
+    #
+    # Also, because the __call__ has been overridden, you can get
+    # the proper timeout by calling:
+    #
+    # Timeout(seconds, green=is_green)
+    #
+    # Timeout is capitalized because in almost all use cases you
+    # can think of this as a class, even though there is a little
+    # more going on.
+    Timeout = _TimeoutMagic((gevent.Timeout, QdbTimeout))
+else:
+    Timeout = QdbTimeout
 
 
 # Don't register the results from these nodes.
-NO_REGISTER_STATEMENTS = {
+NO_REGISTER_STATEMENTS = frozenset((
     # Classes and functions.
     ast.FunctionDef,
     ast.ClassDef,
@@ -176,8 +187,6 @@ NO_REGISTER_STATEMENTS = {
     ast.Assign,
     ast.AugAssign,
 
-    ast.Print,
-
     # Imports
     ast.Import,
     ast.ImportFrom,
@@ -186,7 +195,11 @@ NO_REGISTER_STATEMENTS = {
 
     ast.Global,
     ast.Pass,
-}
+
+    # Python 2 only
+    ast.Print if PY2 else None,
+    ast.Repr if PY2 else None,
+))
 
 
 # Matches valid python names.

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,12 @@ else:
     # just use the regular README.
     LONG_DESCRIPTION = README_MARKDOWN
 
+
+py2_requires = [
+    'contextlib2',
+]
+
+
 setup(
     name='qdb',
     version='0.1.0',
@@ -61,9 +67,8 @@ setup(
         'Topic :: Software Development :: Debuggers',
     ],
     install_requires=[
-        'contextlib2',
         'Logbook',
         'websocket-client',
-    ],
+    ] + py2_requires,
     url="https://github.com/quantopian/qdb"
 )

--- a/setup.py
+++ b/setup.py
@@ -55,17 +55,14 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3'
         'Operating System :: POSIX',
         'Topic :: Software Development :: Debuggers',
     ],
     install_requires=[
         'contextlib2',
-        'gevent',
-        'gevent-websocket',
-        'gipc',
         'Logbook',
-        'six',
         'websocket-client',
     ],
     url="https://github.com/quantopian/qdb"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,8 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from gevent.monkey import patch_all
-patch_all()  # Patch out the modules before executing the tests.
+from qdb.compat import gevent
+if gevent is not None:
+    from gevent.monkey import patch_all
+    patch_all()  # Patch out the modules before executing the tests.
 
 import os
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,9 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from qdb.compat import gevent
-if gevent is not None:
+try:
     from gevent.monkey import patch_all
+except ImportError:
+    pass
+else:
     patch_all()  # Patch out the modules before executing the tests.
 
 import os

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -30,11 +30,16 @@ skip_py3 = skipIf(PY3, 'This test will not work with python3')
 
 class Py2TestMeta(type):
     def __new__(mcls, name, bases, dict_):
+        if PY3:
+            dict_.pop('setUpClass', None)
+            dict_.pop('tearDownClass', None)
+
         return type.__new__(
             mcls,
             name,
             bases,
-            {k: skip_py3(v) for k, v in items(dict_) if k.startswith('test_')},
+            {k: skip_py3(v) if k.startswith('test_') else v
+             for k, v in items(dict_)},
         )
 
 

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,0 +1,46 @@
+#
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+from unittest import skipIf
+from qdb.compat import PY3, items
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+class NonLocal(object):
+    def __init__(self, value):
+        self.value = value
+
+
+skip_py3 = skipIf(PY3, 'This test will not work with python3')
+
+
+class Py2TestMeta(type):
+    def __new__(mcls, name, bases, dict_):
+        return type.__new__(
+            mcls,
+            name,
+            bases,
+            {k: skip_py3(v) for k, v in items(dict_) if k.startswith('test_')},
+        )
+
+
+__all__ = [
+    'NonLocal',
+    'Py2TestMeta',
+    'mock',
+    'skip_py3',
+]

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 from unittest import skipIf
-from qdb.compat import PY3, items
+from qdb.compat import PY3
 
 try:
     from unittest import mock
@@ -28,24 +28,8 @@ class NonLocal(object):
 skip_py3 = skipIf(PY3, 'This test will not work with python3')
 
 
-class Py2TestMeta(type):
-    def __new__(mcls, name, bases, dict_):
-        if PY3:
-            dict_.pop('setUpClass', None)
-            dict_.pop('tearDownClass', None)
-
-        return type.__new__(
-            mcls,
-            name,
-            bases,
-            {k: skip_py3(v) if k.startswith('test_') else v
-             for k, v in items(dict_)},
-        )
-
-
 __all__ = [
     'NonLocal',
-    'Py2TestMeta',
     'mock',
     'skip_py3',
 ]

--- a/tests/test_cmd_manager.py
+++ b/tests/test_cmd_manager.py
@@ -245,6 +245,7 @@ class RemoteCommandManagerTester(TestCase):
             host=self.tracer_host,
             port=self.tracer_port,
             redirect_output=False,
+            green=True,
         )
         sleep(0.01)
         if direction == 'down':
@@ -293,6 +294,7 @@ class RemoteCommandManagerTester(TestCase):
             cmd_manager=self.cmd_manager,
             host=self.tracer_host,
             port=self.tracer_port,
+            green=True,
         )
         signal.signal(db.pause_signal, pause_handler)
         self.server.session_store.send_to_tracer(
@@ -333,6 +335,7 @@ class RemoteCommandManagerTester(TestCase):
             host=self.tracer_host,
             port=self.tracer_port,
             redirect_output=False,
+            green=True,
         )
         sleep(0.01)
         self.server.session_store.send_to_tracer(
@@ -419,6 +422,7 @@ class RemoteCommandManagerTester(TestCase):
             host=self.tracer_host,
             port=self.tracer_port,
             redirect_output=False,
+            green=True,
         )
         sleep(0.01)
         self.server.session_store.send_to_tracer(
@@ -464,6 +468,7 @@ class RemoteCommandManagerTester(TestCase):
             port=self.tracer_port,
             redirect_output=False,
             execution_timeout=1,
+            green=True,
         )
         sleep(0.01)
         self.server.session_store.send_to_tracer(
@@ -503,6 +508,7 @@ class RemoteCommandManagerTester(TestCase):
             host=self.tracer_host,
             port=self.tracer_port,
             redirect_output=False,
+            green=True,
         )
         sleep(0.01)
         db.set_trace(stop=False)
@@ -542,6 +548,7 @@ class RemoteCommandManagerTester(TestCase):
             port=self.tracer_port,
             redirect_output=False,
             skip_fn=skip_fn if use_skip_fn else None,
+            green=True,
         )
         sleep(0.01)
         self.server.session_store.send_to_tracer(

--- a/tests/test_cmd_manager.py
+++ b/tests/test_cmd_manager.py
@@ -253,7 +253,6 @@ class RemoteCommandManagerTester(TestCase):
             host=self.tracer_host,
             port=self.tracer_port,
             redirect_output=False,
-            green=True,
         )
         sleep(0.01)
         if direction == 'down':
@@ -302,7 +301,6 @@ class RemoteCommandManagerTester(TestCase):
             cmd_manager=self.cmd_manager,
             host=self.tracer_host,
             port=self.tracer_port,
-            green=True,
         )
         signal.signal(db.pause_signal, pause_handler)
         self.server.session_store.send_to_tracer(
@@ -343,7 +341,6 @@ class RemoteCommandManagerTester(TestCase):
             host=self.tracer_host,
             port=self.tracer_port,
             redirect_output=False,
-            green=True,
         )
         sleep(0.01)
         self.server.session_store.send_to_tracer(
@@ -430,7 +427,6 @@ class RemoteCommandManagerTester(TestCase):
             host=self.tracer_host,
             port=self.tracer_port,
             redirect_output=False,
-            green=True,
         )
         sleep(0.01)
         self.server.session_store.send_to_tracer(
@@ -476,7 +472,6 @@ class RemoteCommandManagerTester(TestCase):
             port=self.tracer_port,
             redirect_output=False,
             execution_timeout=1,
-            green=True,
         )
         sleep(0.01)
         self.server.session_store.send_to_tracer(
@@ -516,7 +511,6 @@ class RemoteCommandManagerTester(TestCase):
             host=self.tracer_host,
             port=self.tracer_port,
             redirect_output=False,
-            green=True,
         )
         sleep(0.01)
         db.set_trace(stop=False)
@@ -556,7 +550,6 @@ class RemoteCommandManagerTester(TestCase):
             port=self.tracer_port,
             redirect_output=False,
             skip_fn=skip_fn if use_skip_fn else None,
-            green=True,
         )
         sleep(0.01)
         self.server.session_store.send_to_tracer(

--- a/tests/test_cmd_manager.py
+++ b/tests/test_cmd_manager.py
@@ -23,18 +23,19 @@ from nose_parameterized import parameterized
 
 from qdb import Qdb
 from qdb.comm import RemoteCommandManager, ServerLocalCommandManager, fmt_msg
-from qdb.compat import with_metaclass, PY2, gevent
+from qdb.compat import PY2, gevent
 from qdb.errors import (
     QdbFailedToConnect,
     QdbAuthenticationError,
     QdbExecutionTimeout,
 )
 
+from tests import fix_filename
+from tests.compat import mock, skip_py3
+
+
 if PY2:
     from qdb.server import QdbServer
-
-from tests import fix_filename
-from tests.compat import Py2TestMeta, mock
 
 patch = mock.patch
 MagicMock = mock.MagicMock
@@ -55,12 +56,13 @@ def set_break_params(tracer, filename, lineno, temporary=False, cond=None,
     }
 
 
-class RemoteCommandManagerTester(with_metaclass(Py2TestMeta, TestCase)):
+class RemoteCommandManagerTester(TestCase):
     """
     Tests the various behaviors that the RemoteCommandManager should conform
     to. Some tests rely on how the command manager affects the tracer that it
     is managing.
     """
+    @skip_py3
     @classmethod
     def setUpClass(cls):
         """
@@ -584,6 +586,7 @@ class ServerLocalCommandManagerTester(RemoteCommandManagerTester):
     the ServerLocalCommandManager. This makes sure that the same behavior holds
     for the two types of command managers.
     """
+    @skip_py3
     @classmethod
     def setUpClass(cls):
         cls.setup_server()

--- a/tests/test_cmd_manager.py
+++ b/tests/test_cmd_manager.py
@@ -39,6 +39,7 @@ from tests.compat import Py2TestMeta, mock
 patch = mock.patch
 MagicMock = mock.MagicMock
 
+
 def set_break_params(tracer, filename, lineno, temporary=False, cond=None,
                      funcname=None, **kwargs):
     """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,7 +98,7 @@ class QdbConfigTester(TestCase):
         Tests reading an extra config file.
         """
         with NamedTemporaryFile(dir=self.home) as t:
-            t.write(self.contents)
+            t.write(self.contents.encode('utf-8'))
             t.flush()
 
             self._test_file(files=(t.name,))

--- a/tests/test_file_cache.py
+++ b/tests/test_file_cache.py
@@ -12,12 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from itertools import count, izip
+from itertools import count
 from textwrap import dedent
 from unittest import TestCase
 
 from qdb import Qdb
 from qdb.comm import NopCommandManager
+from qdb.compat import zip, range
 
 from tests import fix_filename
 
@@ -45,7 +46,7 @@ class QdbFileCacheTester(TestCase):
         # Check the whole 'file'.
         self.assertEquals(db.get_file('file'), contents[:-1])  # drop '\n'
 
-        for n in xrange(1, 5):
+        for n in range(1, 5):
             # Check all the lines.
             self.assertEquals('line %d' % n, db.get_line('file', n))
 
@@ -67,7 +68,7 @@ class QdbFileCacheTester(TestCase):
             # Assert that querying the entire file works.
             self.assertEquals(db.get_file(filename), contents)
 
-            for n, line in izip(count(start=1), contents.splitlines()):
+            for n, line in zip(count(start=1), contents.splitlines()):
                 # Iterate over all the lines of the file, asserting that we
                 # have saved them correctly. This also asserts that the line
                 # indexing is working as intended.

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -189,30 +189,30 @@ class TimeoutTester(TestCase):
         """
         Tests that the smart constructor returns the correct type.
         """
-        green = Timeout(1, green=True)
+        green = Timeout(1)
         self.assertTrue(isinstance(green, gevent.Timeout))
-        not_green = Timeout(1, green=False)
+        not_green = Timeout(1, no_gevent=True)
         self.assertTrue(isinstance(not_green, QdbTimeout))
 
     @parameterized.expand([(False,), (True,)])
-    def test_smart_constructor_can_catch(self, green):
+    def test_smart_constructor_can_catch(self, no_gevent):
         """
         Asserts that users may use the normal try/catch syntax with
         the Timeout smart constructor.
         This test will fail if except Timeout does NOT catch the exception.
         """
         try:
-            raise Timeout(1, green=green)
+            raise Timeout(1, no_gevent=no_gevent)
         except Timeout:
             pass
 
     @parameterized.expand([(False,), (True,)])
-    def test_timout_isinstance(self, green):
+    def test_timout_isinstance(self, no_gevent):
         """
         Asserts that the Timeout smart constructor returns are instances of
         Timeout.
         """
-        self.assertIsInstance(Timeout(1, green=green), Timeout)
+        self.assertIsInstance(Timeout(1, no_gevent=no_gevent), Timeout)
 
 
 class PrognTester(TestCase):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -18,10 +18,9 @@ import sys
 import time
 from unittest import TestCase
 
-import gevent
-from mock import MagicMock
 from nose_parameterized import parameterized
 
+from qdb.compat import gevent, keys
 from qdb.errors import QdbPrognEndsInStatement
 from qdb.utils import (
     default_eval_fn,
@@ -30,6 +29,8 @@ from qdb.utils import (
     QdbTimeout,
     progn,
 )
+
+from tests.compat import mock, skip_py3
 
 
 class FakeFrame(object):
@@ -183,6 +184,7 @@ class TimeoutTester(TestCase):
 
         self.assertIs(signal.getsignal(tsignal), existing_handler)
 
+    @skip_py3
     def test_timeout_smart_constructor(self):
         """
         Tests that the smart constructor returns the correct type.
@@ -276,15 +278,15 @@ class PrognTester(TestCase):
 
         # Make sure the register function name didn't persist.
         self.assertEqual(
-            ['__builtins__', 'global_'],
-            stackframe.f_globals.keys()
+            sorted(('__builtins__', 'global_')),
+            sorted(keys(stackframe.f_globals)),
         )
 
     def test_progn_uses_custom_eval_fn(self):
         """
         Assert that the progn function uses custom eval functions properly.
         """
-        eval_fn = MagicMock()
+        eval_fn = mock.MagicMock()
 
         try:
             progn('2 + 2', eval_fn=eval_fn)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -56,7 +56,7 @@ def recv_tracer_event(sck):
     Reads an event off the socket.
     """
     try:
-        return next(get_events_from_socket(sck, green=True))
+        return next(get_events_from_socket(sck))
     except StopIteration:
         return {}
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,7 +19,9 @@ from nose_parameterized import parameterized
 from struct import pack
 
 from qdb.comm import fmt_msg, fmt_err_msg, get_events_from_socket
-from qdb.compat import gevent, with_metaclass, PY2
+from qdb.compat import gevent, PY2
+
+from tests.compat import skip_py3
 
 if PY2:
     # These need python 2
@@ -31,8 +33,6 @@ if PY2:
     )
     from qdb.server.session_store import ALLOW_ORPHANS
     from qdb.server.client import DEFAULT_ROUTE_FMT
-
-from tests.compat import Py2TestMeta
 
 
 def send_tracer_event(sck, event, payload):
@@ -68,7 +68,8 @@ def recv_client_event(ws):
     return json.loads(ws.recv())
 
 
-class ServerTester(with_metaclass(Py2TestMeta, TestCase)):
+@skip_py3
+class ServerTester(TestCase):
     def test_start_stop(self):
         """
         Tests starting and stopping the server.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,17 +28,12 @@ from qdb.server import (
 from qdb.server.session_store import ALLOW_ORPHANS
 from qdb.server.client import DEFAULT_ROUTE_FMT
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-
 
 def send_tracer_event(sck, event, payload):
     """
     Sends an event over the socket.
     """
-    msg = fmt_msg(event, payload, serial=pickle.dumps)
+    msg = fmt_msg(event, payload, serial=json.dumps)
     sck.sendall(pack('>i', len(msg)))
     sck.sendall(msg)
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -19,7 +19,7 @@ from unittest import TestCase
 
 from qdb import Qdb
 from qdb.comm import NopCommandManager
-from qdb.compat import StringIO, gevent
+from qdb.compat import StringIO
 from qdb.errors import QdbExecutionTimeout
 from qdb.utils import Timeout
 
@@ -106,7 +106,7 @@ class TracerTester(TestCase):
         db.cmd_manager.enqueue(lambda t: t.set_step())
 
         stepped = False
-        with Timeout(0.1, False, green=gevent):
+        with Timeout(0.1, False):
             db.set_trace()
             stepped = True
 
@@ -120,7 +120,7 @@ class TracerTester(TestCase):
         db.cmd_manager.user_wait(0.2)
 
         stepped = over_stepped = False
-        with Timeout(0.1, False, green=gevent):
+        with Timeout(0.1, False):
             db.set_trace()
             stepped = True
             over_stepped = True
@@ -149,7 +149,7 @@ class TracerTester(TestCase):
         def f():
             f_called.value = True
 
-        with Timeout(0.1, False, green=gevent):
+        with Timeout(0.1, False):
             db.set_trace()
             f()
 
@@ -174,7 +174,7 @@ class TracerTester(TestCase):
         db.cmd_manager.enqueue(lambda t: t.set_step())
         db.cmd_manager.user_wait(1.2)
 
-        with Timeout(0.1, False, green=gevent):
+        with Timeout(0.1, False):
             db.set_trace()
             f()
 
@@ -196,7 +196,7 @@ class TracerTester(TestCase):
         db.cmd_manager.user_wait(0.2)
 
         line_1 = line_2 = line_3 = False
-        with Timeout(0.1, False, green=gevent):
+        with Timeout(0.1, False):
             db.set_trace()
             line_1 = True  # EDIT IN BOTH PLACES
             line_2 = True
@@ -226,7 +226,7 @@ class TracerTester(TestCase):
         db.cmd_manager.enqueue(lambda t: t.set_continue())
         db.cmd_manager.user_wait(0.2)
         line_1 = line_2 = line_3 = False
-        with Timeout(0.1, False, green=gevent):
+        with Timeout(0.1, False):
             db.set_trace()
             line_1 = True
             line_2 = True
@@ -261,7 +261,7 @@ class TracerTester(TestCase):
         db.cmd_manager.enqueue(lambda t: t.set_continue())
         db.cmd_manager.user_wait(0.2)
         line_1 = line_2 = line_3 = False
-        with Timeout(0.1, False, green=gevent):
+        with Timeout(0.1, False):
             db.set_trace()
             line_1 = True
             line_2 = True
@@ -283,7 +283,7 @@ class TracerTester(TestCase):
         db = Qdb(cmd_manager=QueueCommandManager)
         db.cmd_manager.user_wait(0.2)
         line_1 = False
-        with Timeout(0.1, False, green=gevent):
+        with Timeout(0.1, False):
             db.set_trace()
             line_1 = True  # EDIT IN BOTH PLACES
 
@@ -304,7 +304,7 @@ class TracerTester(TestCase):
         )
         db.cmd_manager.user_wait(0.2)
         line_1 = line_2 = line_3 = False
-        with Timeout(0.1, False, green=gevent):
+        with Timeout(0.1, False):
             db.set_trace(stop=False)  # Should not stop us here.
             line_1 = True
             line_2 = True
@@ -320,7 +320,7 @@ class TracerTester(TestCase):
 
         db = Qdb(cmd_manager=NopCommandManager)
         line_1 = False
-        with Timeout(0.1, False, green=gevent):
+        with Timeout(0.1, False):
             db.set_trace(stop=False)
             line_1 = True
 
@@ -534,7 +534,7 @@ class TracerTester(TestCase):
             sys._getframe().f_lineno + line_offset,
             temporary=True,
         )
-        with Timeout(0.1, False, green=gevent):
+        with Timeout(0.1, False):
             db.set_trace(stop=False)
             while loop_counter < 10:
                 loop_counter += 1
@@ -564,7 +564,7 @@ class TracerTester(TestCase):
         db.set_trace(stop=False)
 
         continued = False
-        with Timeout(0.1, green=gevent):
+        with Timeout(0.1):
             db.set_trace(stop=False)
             for n in range(2):
                 pass

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -19,7 +19,7 @@ from unittest import TestCase
 
 from qdb import Qdb
 from qdb.comm import NopCommandManager
-from qdb.compat import StringIO
+from qdb.compat import StringIO, gevent
 from qdb.errors import QdbExecutionTimeout
 from qdb.utils import Timeout
 
@@ -106,7 +106,7 @@ class TracerTester(TestCase):
         db.cmd_manager.enqueue(lambda t: t.set_step())
 
         stepped = False
-        with Timeout(0.1, False):
+        with Timeout(0.1, False, green=gevent):
             db.set_trace()
             stepped = True
 
@@ -120,7 +120,7 @@ class TracerTester(TestCase):
         db.cmd_manager.user_wait(0.2)
 
         stepped = over_stepped = False
-        with Timeout(0.1, False):
+        with Timeout(0.1, False, green=gevent):
             db.set_trace()
             stepped = True
             over_stepped = True
@@ -149,7 +149,7 @@ class TracerTester(TestCase):
         def f():
             f_called.value = True
 
-        with Timeout(0.1, False):
+        with Timeout(0.1, False, green=gevent):
             db.set_trace()
             f()
 
@@ -174,7 +174,7 @@ class TracerTester(TestCase):
         db.cmd_manager.enqueue(lambda t: t.set_step())
         db.cmd_manager.user_wait(1.2)
 
-        with Timeout(0.1, False):
+        with Timeout(0.1, False, green=gevent):
             db.set_trace()
             f()
 
@@ -196,7 +196,7 @@ class TracerTester(TestCase):
         db.cmd_manager.user_wait(0.2)
 
         line_1 = line_2 = line_3 = False
-        with Timeout(0.1, False):
+        with Timeout(0.1, False, green=gevent):
             db.set_trace()
             line_1 = True  # EDIT IN BOTH PLACES
             line_2 = True
@@ -226,7 +226,7 @@ class TracerTester(TestCase):
         db.cmd_manager.enqueue(lambda t: t.set_continue())
         db.cmd_manager.user_wait(0.2)
         line_1 = line_2 = line_3 = False
-        with Timeout(0.1, False):
+        with Timeout(0.1, False, green=gevent):
             db.set_trace()
             line_1 = True
             line_2 = True
@@ -261,7 +261,7 @@ class TracerTester(TestCase):
         db.cmd_manager.enqueue(lambda t: t.set_continue())
         db.cmd_manager.user_wait(0.2)
         line_1 = line_2 = line_3 = False
-        with Timeout(0.1, False):
+        with Timeout(0.1, False, green=gevent):
             db.set_trace()
             line_1 = True
             line_2 = True
@@ -283,7 +283,7 @@ class TracerTester(TestCase):
         db = Qdb(cmd_manager=QueueCommandManager)
         db.cmd_manager.user_wait(0.2)
         line_1 = False
-        with Timeout(0.1, False):
+        with Timeout(0.1, False, green=gevent):
             db.set_trace()
             line_1 = True  # EDIT IN BOTH PLACES
 
@@ -304,7 +304,7 @@ class TracerTester(TestCase):
         )
         db.cmd_manager.user_wait(0.2)
         line_1 = line_2 = line_3 = False
-        with Timeout(0.1, False):
+        with Timeout(0.1, False, green=gevent):
             db.set_trace(stop=False)  # Should not stop us here.
             line_1 = True
             line_2 = True
@@ -320,7 +320,7 @@ class TracerTester(TestCase):
 
         db = Qdb(cmd_manager=NopCommandManager)
         line_1 = False
-        with Timeout(0.1, False):
+        with Timeout(0.1, False, green=gevent):
             db.set_trace(stop=False)
             line_1 = True
 
@@ -534,7 +534,7 @@ class TracerTester(TestCase):
             sys._getframe().f_lineno + line_offset,
             temporary=True,
         )
-        with Timeout(0.1, False):
+        with Timeout(0.1, False, green=gevent):
             db.set_trace(stop=False)
             while loop_counter < 10:
                 loop_counter += 1
@@ -564,7 +564,7 @@ class TracerTester(TestCase):
         db.set_trace(stop=False)
 
         continued = False
-        with Timeout(0.1):
+        with Timeout(0.1, green=gevent):
             db.set_trace(stop=False)
             for n in range(2):
                 pass

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,11 +14,14 @@
 # limitations under the License.
 from collections import namedtuple
 import json
-
-import gevent
-from gevent.queue import Queue, Empty
+from time import sleep
 
 from qdb.comm import CommandManager, NopCommandManager
+from qdb.compat import gevent, PY3
+
+
+if gevent is None:
+    from queue import Queue, Empty
 
 
 class QueueCommandManager(CommandManager):
@@ -41,7 +44,7 @@ class QueueCommandManager(CommandManager):
         """
         Simulates waiting on the user to feed us input for duration seconds.
         """
-        self.enqueue(lambda t: gevent.sleep(duration))
+        self.enqueue(lambda t: sleep(duration + int(PY3)))
 
     def clear(self):
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,15 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import namedtuple
+import json
+
 import gevent
 from gevent.queue import Queue, Empty
 
 from qdb.comm import CommandManager, NopCommandManager
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
 
 
 class QueueCommandManager(CommandManager):
@@ -64,7 +61,7 @@ class QueueCommandManager(CommandManager):
 
     def send(self, msg):
         # Collect the output so that we can make assertions about it.
-        self.sent.append(pickle.loads(msg))
+        self.sent.append(json.loads(msg))
 
     user_stop = clear
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,11 +17,12 @@ import json
 from time import sleep
 
 from qdb.comm import CommandManager, NopCommandManager
-from qdb.compat import gevent, PY3
+from qdb.compat import PY3
 
-
-if gevent is None:
+if PY3:
     from queue import Queue, Empty
+else:
+    from Queue import Queue, Empty
 
 
 class QueueCommandManager(CommandManager):
@@ -44,7 +45,7 @@ class QueueCommandManager(CommandManager):
         """
         Simulates waiting on the user to feed us input for duration seconds.
         """
-        self.enqueue(lambda t: sleep(duration + int(PY3)))
+        self.enqueue(lambda t: sleep(duration + 1))
 
     def clear(self):
         """


### PR DESCRIPTION
it is passing, and we only need to skip like 70 tests to get py3 working!

To fix the issue of a python 3 tracer talking to a python 2 server over pickle, we now use json to talk at this point. This means that we could potentially abstract the tracer and server such that one of them was not even in python! 