### PR TITLE
DOC: Fixes error in sample script provided in 'Getting started' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ def f():
 
 
 def main():
-    qdb.set_trace(
+    set_trace(
         uuid='qdb',
         host='localhost',
         port=8001,


### PR DESCRIPTION
set_trace is directly imported by qdb.set_trace was used in the main()
function.