### PR TITLE
Upgrade `gevent` to 1.2.2 for security vulnerability

### DIFF
--- a/etc/requirements_gevent.txt
+++ b/etc/requirements_gevent.txt
@@ -1,5 +1,5 @@
 # Gevent related
-gevent==1.0.2
+gevent==1.2.2
 gevent-websocket==0.9.3
 greenlet==0.4.2
 gipc==0.4.0


### PR DESCRIPTION
CVE: No CVE has been posted