### PR TITLE
Disable tracer if it fails to start properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
+  - "3.6"
 
 install:
   - make requirements
@@ -11,3 +11,7 @@ before_script:
 
 script:
   - make test
+
+branches:
+  only:
+    - master

--- a/qdb/comm.py
+++ b/qdb/comm.py
@@ -296,7 +296,7 @@ class RemoteCommandManager(CommandManager):
         """
         log.info('Connecting to (%s, %d)' % tracer.address)
 
-        for n in range(tracer.retry_attepts):
+        for n in range(tracer.retry_attempts):
             # Try to connect to the server.
             try:
                 self.socket = socket.create_connection(tracer.address)
@@ -315,7 +315,7 @@ class RemoteCommandManager(CommandManager):
             )
             raise QdbFailedToConnect(
                 tracer.address,
-                tracer.retry_attepts
+                tracer.retry_attempts
             )
         log.info('Client %s connected to (%s, %d)'
                  % (tracer.uuid, tracer.address[0],
@@ -334,7 +334,7 @@ class RemoteCommandManager(CommandManager):
                   tracer.pause_signal),
         )
         with Timeout(5, QdbFailedToConnect(tracer.address,
-                                           tracer.retry_attepts)):
+                                           tracer.retry_attempts)):
             # Receive a message to know that the reader is ready to begin.
             while True:
                 try:

--- a/qdb/config.py
+++ b/qdb/config.py
@@ -41,7 +41,7 @@ DEFAULT_OPTIONS = {
     'skip_fn': None,
     'pause_signal': None,
     'redirect_output': True,
-    'retry_attepts': 10,
+    'retry_attempts': 10,
     'uuid': 'qdb',
     'cmd_manager': None,
     'green': False,

--- a/qdb/errors.py
+++ b/qdb/errors.py
@@ -41,18 +41,18 @@ class QdbFailedToConnect(QdbError):
     """
     Error signaling that qdb was unable to connect for some reason.
     """
-    def __init__(self, address, retry_attepts):
+    def __init__(self, address, retry_attempts):
         self.address = address
-        self.retry_attepts = retry_attepts
+        self.retry_attempts = retry_attempts
 
     def __str__(self):
-        return 'Failed to connect to %s after %d retries.' \
-            % (self.address, self.retry_attepts)
+        return 'Failed to connect to %s after %d attempts.' \
+            % (self.address, self.retry_attempts)
 
     def __repr__(self):
         return 'QdbFailedToConnect(%r, %d)' % (
             self.address,
-            self.retry_attepts,
+            self.retry_attempts,
         )
 
 

--- a/qdb/tracer.py
+++ b/qdb/tracer.py
@@ -91,8 +91,10 @@ class Qdb(Bdb, object):
         called.
         """
         if not cls._instance:
-            cls._instance = super(Qdb, cls).__new__(cls)
-            cls._instance._init(*args, **kwargs)
+            inst = super(Qdb, cls).__new__(cls)
+            # `_init` might raise, so don't save as `_instance` yet:
+            inst._init(*args, **kwargs)
+            cls._instance = inst
         return cls._instance
 
     def __init__(self, *args, **kwargs):

--- a/qdb/tracer.py
+++ b/qdb/tracer.py
@@ -132,7 +132,7 @@ class Qdb(Bdb, object):
             default_exception_serializer
         self.eval_fn = config.eval_fn or default_eval_fn
         self._file_cache = {}
-        self.retry_attepts = config.retry_attepts
+        self.retry_attempts = config.retry_attempts
         self.repr_fn = config.repr_fn
         self._skip_fn = config.skip_fn or (lambda _: False)
         self.pause_signal = config.pause_signal \

--- a/tests/test_cmd_manager.py
+++ b/tests/test_cmd_manager.py
@@ -111,7 +111,7 @@ class RemoteCommandManagerTester(with_metaclass(Py2TestMeta, TestCase)):
         tracer = MagicMock()
         tracer.address = self.tracer_host, self.tracer_port
         tracer.pause_signal = signal.SIGUSR2
-        tracer.retry_attepts = 1
+        tracer.retry_attempts = 1
         tracer.local = 0, 0
         tracer.uuid = 'mock'
         tracer.watchlist = {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,7 +37,7 @@ class QdbConfigTester(TestCase):
                 'skip_fn': 'user-set',
                 'pause_signal': 'user-set',
                 'redirect_output': 'user-set',
-                'retry_attepts': 'user-set',
+                'retry_attempts': 'user-set',
                 'uuid': 'user-set',
                 'cmd_manager': 'user-set',
                 'green': 'user-set',

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -58,7 +58,7 @@ class TracerTester(TestCase):
         with self.assertRaises(TypeError):
             Qdb(config=True, merge=False, keyword=True)
 
-        Qdb._instance = None
+        self.assertIs(Qdb._instance, None)
 
     def test_as_ctx_mgr(self):
         """


### PR DESCRIPTION
Also fixed a typo.

Exceptions raised from `_init` meant that the singleton was left in a bad state.